### PR TITLE
Correct a null check in BilSniffer (FileTypeSupport samples)

### DIFF
--- a/FileTypeSupport/Sdl.Sdk.FileTypeSupport.Samples.Bil/BilSniffer.cs
+++ b/FileTypeSupport/Sdl.Sdk.FileTypeSupport.Samples.Bil/BilSniffer.cs
@@ -71,7 +71,7 @@ namespace Sdl.Sdk.FileTypeSupport.Samples.Bil
                 }
 
                 XmlAttribute target = doc.DocumentElement.Attributes[_TargetLanguage];
-                if (source != null)
+                if (target != null)
                 {
                     info.DetectedTargetLanguage =
                         new Sdl.FileTypeSupport.Framework.Pair<Language, DetectionLevel>(new Language(target.Value),


### PR DESCRIPTION
Correct a null check at language detection in BilSniffer (FileTypeSupport samples)
